### PR TITLE
convert to creating a separate DB instead of ATTACHing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,25 @@
-# 0.1.*
+# CHANGELOG
 
-## 0.1.1 - 24-12-17
+## 0.2.*
+
+### 0.2.0 - ATTACH no more!
+
+No more ATTACH-ing: we can now create independent sqlite databases, so prepending the db name is no longer required
+and there is no risk of fouling up the zotero db by accident!
+
+Each DB connection now has an independent mutex, so multiple DBs can be use asynchronously 
+and plugins should not interfere with one another.
+
+We also have a basic set of tests thanks to the excellent `zotero-plugin-scaffold` :)
+
+## 0.1.*
+
+### 0.1.1 - 24-12-17
 
 - bugfix: correct type narrowing for void | object[] type when unpacking
 - bugfix: kysely as a peerDependency rather than direct dependency
 
-## 0.1.0 - 24-12-04
+### 0.1.0 - 24-12-04
 
 Initial version with basic query functionality :)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kysely-zotero-dialect",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Use kysely within zotero plugins",
   "main": "src/index.ts",
   "repository": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,3 @@
 export interface ZoteroDialectConfig {
   db_name: string;
-  db_path: string;
 }

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -7,11 +7,17 @@ import {
 import {unpackRowProxy} from './util';
 
 export class ZoteroDatabaseConnection implements DatabaseConnection {
+  readonly db: typeof Zotero.DB;
+
+  constructor(db: typeof Zotero.DB) {
+    this.db = db;
+  }
+
   async executeQuery<O>(compiledQuery: CompiledQuery): Promise<QueryResult<O>> {
     const {sql, parameters, query} = compiledQuery;
 
     if (SelectQueryNode.is(query)) {
-      const proxyRows = await Zotero.DB.queryAsync(sql, parameters);
+      const proxyRows = await this.db.queryAsync(sql, parameters);
       if (typeof proxyRows === 'undefined') {
         return {rows: []};
       } else {
@@ -29,7 +35,7 @@ export class ZoteroDatabaseConnection implements DatabaseConnection {
         }
       }
     } else {
-      const proxyRows = await Zotero.DB.queryAsync(sql, parameters);
+      const proxyRows = await this.db.queryAsync(sql, parameters);
       // const statement = 'SELECT last_insert_rowid() AS lastInsertRowID';
       // const lastInsertRowID = await Zotero.DB.queryAsync(statement, []);
 

--- a/src/query-compiler.ts
+++ b/src/query-compiler.ts
@@ -1,18 +1,8 @@
-import {SqliteQueryCompiler, FromNode, CreateIndexNode} from 'kysely';
+import {SqliteQueryCompiler, CreateIndexNode} from 'kysely';
 
 export class ZoteroQueryCompiler extends SqliteQueryCompiler {
-  /*
-   * TODO: Append the database name to every `from` query
-   */
-  protected override visitFrom(node: FromNode) {
-    // this.append('from ');
-    // this.compileList(node.froms);
-    super.visitFrom(node);
-  }
-
   protected override visitCreateIndex(node: CreateIndexNode): void {
     // Override to correctly place the database name before the index name
-
     this.append('create ');
 
     if (node.unique) {

--- a/test/fixtures/db.ts
+++ b/test/fixtures/db.ts
@@ -28,21 +28,21 @@ const migration: Migration = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   up: async (db: Kysely<any>): Promise<void> => {
     await db.schema
-      .createTable('test.table_a')
+      .createTable('table_a')
       .addColumn('id', 'integer', col => col.primaryKey())
       .addColumn('value_a', 'text')
       .execute();
 
     await db.schema
-      .createTable('test.table_b')
+      .createTable('table_b')
       .addColumn('id', 'integer', col => col.primaryKey())
       .addColumn('value_a', 'text')
       .execute();
   },
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   down: async (db: Kysely<any>): Promise<void> => {
-    await db.schema.dropTable('test.table_a');
-    await db.schema.dropTable('test.table_b');
+    await db.schema.dropTable('table_a');
+    await db.schema.dropTable('table_b');
   },
 };
 export const migrationProvider: MigrationProvider = {
@@ -54,7 +54,6 @@ export const migrationProvider: MigrationProvider = {
 };
 export const config: ZoteroDialectConfig = {
   db_name: 'test',
-  db_path: 'test.sqlite',
 };
 
 export async function createDB(): Promise<Kysely<Database>> {


### PR DESCRIPTION
Someone on the zotero mailing list pointed out that there was a way to create an independent DB connection rather than the ATTACH strategy that `zotero-better-bibtex` was using, so this simplifies the implementation a bit and no longer requires that we have a single mutex/prepend the DB name every time, etc. It also gives a clearer path for using the zotero db directly.